### PR TITLE
Added implementation and unit tests for handle_missing(). Using pd.api.types was an idea from LLM.

### DIFF
--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -32,4 +32,37 @@ def handle_missing(df, strategy='drop', columns=None):
     ValueError
         If `strategy` is not a permitted strategy.
     """
-    pass
+
+    if not isinstance(strategy, str):
+        raise TypeError('Strategy must be a string.')
+
+    if strategy not in ['mean', 'median', 'max', 'min', 'mode', 'drop']:
+        raise ValueError('Strategy must be permitted')
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError('df must be a pandas DataFrame.')
+
+    if not isinstance(columns, list) and columns is not None:
+        raise TypeError('columns must be a list.')
+
+    for col in columns:
+        if col not in df.columns:
+            raise ValueError(f'Column {col} not in dataframe')
+
+        if strategy == 'drop':
+            df[col] = df[col].dropna()
+
+        if strategy == 'mean':
+            df[col] = df[col].fillna(df[col].mean())
+
+        if strategy == 'median':
+            df[col] = df[col].fillna(df[col].median())
+
+        if strategy == 'max':
+            df[col] = df[col].fillna(df[col].max())
+
+        if strategy == 'min':
+            df[col] = df[col].fillna(df[col].min())
+
+        if strategy == 'mode':
+            df[col] = df[col].fillna(df[col].mode())

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -45,24 +45,35 @@ def handle_missing(df, strategy='drop', columns=None):
     if not isinstance(columns, list) and columns is not None:
         raise TypeError('columns must be a list.')
 
+    if columns is None:
+        columns = [None]
+
     for col in columns:
         if col not in df.columns:
             raise ValueError(f'Column {col} not in dataframe')
 
+        if df[col].dtype not in ['object', 'category', 'bool', 'int', 'float', 'str']:
+            raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
+
         if strategy == 'drop':
             df[col] = df[col].dropna()
 
-        if strategy == 'mean':
-            df[col] = df[col].fillna(df[col].mean())
+        if df[col].dtype in ['int', 'float']:
+            if strategy == 'mean':
+                df[col] = df[col].fillna(df[col].mean())
 
-        if strategy == 'median':
-            df[col] = df[col].fillna(df[col].median())
+            if strategy == 'median':
+                df[col] = df[col].fillna(df[col].median())
 
-        if strategy == 'max':
-            df[col] = df[col].fillna(df[col].max())
+            if strategy == 'max':
+                df[col] = df[col].fillna(df[col].max())
 
-        if strategy == 'min':
-            df[col] = df[col].fillna(df[col].min())
+            if strategy == 'min':
+                df[col] = df[col].fillna(df[col].min())
 
-        if strategy == 'mode':
-            df[col] = df[col].fillna(df[col].mode())
+            if strategy == 'mode':
+                df[col] = df[col].fillna(df[col].mode())
+
+        if df[col].dtype in ['object', 'category', 'bool']:
+            if strategy == 'mode':
+                df[col] = df[col].fillna(df[col].mode())

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -71,20 +71,23 @@ def handle_missing(df, strategy='drop', columns=None):
             if strategy == 'mean':
                 df[col] = df[col].fillna(df[col].mean())
 
-            if strategy == 'median':
+            elif strategy == 'median':
                 df[col] = df[col].fillna(df[col].median())
 
-            if strategy == 'max':
+            elif strategy == 'max':
                 df[col] = df[col].fillna(df[col].max())
 
-            if strategy == 'min':
+            elif strategy == 'min':
                 df[col] = df[col].fillna(df[col].min())
 
-            if strategy == 'mode':
+            elif strategy == 'mode':
                 df[col] = df[col].fillna(df[col].mode())
 
-        if df[col].dtype in ['object', 'category', 'bool']:
+        elif df[col].dtype in ['object', 'category', 'bool']:
             if strategy == 'mode':
-                df[col] = df[col].fillna(df[col].mode())
+                if df[col].mode().shape[0] == 1:
+                    df[col] = df[col].fillna(df[col].mode())
+                else:
+                    df[col] = df[col].fillna(df[col].mode().iloc[0])
 
     return df

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -58,8 +58,12 @@ def handle_missing(df, strategy='drop', columns=None):
         if df[col].dtype not in ['object', 'category', 'bool', 'int', 'float', 'str']:
             raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
 
+        if df[col].isna().sum() == 0:
+            continue
+
         if strategy == 'drop':
             df = df.dropna(subset=[col], inplace=True)
+            continue
 
         if df[col].dtype in ['int', 'float']:
             if strategy == 'mean':

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -64,7 +64,7 @@ def handle_missing(df, strategy='drop', columns=None):
         if df[col].isna().sum() == 0:
             continue
 
-        if df[col].dtype in ['int', 'float']:
+        if pd.api.types.is_numeric_dtype(df[col]):
             if strategy == 'mean':
                 df[col] = df[col].fillna(df[col].mean())
 
@@ -83,7 +83,7 @@ def handle_missing(df, strategy='drop', columns=None):
             else:
                 raise TypeError(f'Strategy {strategy} cannot be used for dtype of column {col}.')
 
-        elif df[col].dtype in ['object', 'category', 'bool']:
+        elif pd.api.types.is_object_dtype(df[col]):
             if strategy == 'mode':
                 if df[col].mode().shape[0] == 1:
                     df[col] = df[col].fillna(df[col].mode())

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -37,7 +37,7 @@ def handle_missing(df, strategy='drop', columns=None):
         raise TypeError('Strategy must be a string.')
 
     if strategy not in ['mean', 'median', 'max', 'min', 'mode', 'drop']:
-        raise ValueError('Strategy must be permitted')
+        raise ValueError('Strategy must be permitted.')
 
     if not isinstance(df, pd.DataFrame):
         raise TypeError('df must be a pandas DataFrame.')
@@ -50,7 +50,10 @@ def handle_missing(df, strategy='drop', columns=None):
 
     for col in columns:
         if col not in df.columns:
-            raise ValueError(f'Column {col} not in dataframe')
+            raise ValueError(f'Column {col} not in dataframe.')
+
+        if df[col].isna().sum() == df[col].shape[0]:
+            raise ValueError(f'Column {col} only contains NaN.')
 
         if df[col].dtype not in ['object', 'category', 'bool', 'int', 'float', 'str']:
             raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -58,14 +58,11 @@ def handle_missing(df, strategy='drop', columns=None):
             raise ValueError(f'Column {col} only contains NaN.')
 
         if strategy == 'drop':
-            df = df.dropna(subset=[col], inplace=True)
+            df = df.dropna(subset=[col])
             continue
 
         if df[col].isna().sum() == 0:
             continue
-
-        if df[col].dtype not in ['object', 'category', 'bool', 'int', 'float', 'str']:
-            raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
 
         if df[col].dtype in ['int', 'float']:
             if strategy == 'mean':
@@ -83,11 +80,19 @@ def handle_missing(df, strategy='drop', columns=None):
             elif strategy == 'mode':
                 df[col] = df[col].fillna(df[col].mode())
 
+            else:
+                raise TypeError(f'Strategy {strategy} cannot be used for dtype of column {col}.')
+
         elif df[col].dtype in ['object', 'category', 'bool']:
             if strategy == 'mode':
                 if df[col].mode().shape[0] == 1:
                     df[col] = df[col].fillna(df[col].mode())
                 else:
                     df[col] = df[col].fillna(df[col].mode().iloc[0])
+            else:
+                raise TypeError(f'Strategy {strategy} cannot be used for dtype of column {col}.')
+
+        else:
+            raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
 
     return df

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -33,14 +33,14 @@ def handle_missing(df, strategy='drop', columns=None):
         If `strategy` is not a permitted strategy.
     """
 
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError('df must be a pandas DataFrame.')
+
     if not isinstance(strategy, str):
         raise TypeError('Strategy must be a string.')
 
     if strategy not in ['mean', 'median', 'max', 'min', 'mode', 'drop']:
         raise ValueError('Strategy must be permitted.')
-
-    if not isinstance(df, pd.DataFrame):
-        raise TypeError('df must be a pandas DataFrame.')
 
     if columns is None:
         columns = df.columns.tolist()

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -46,7 +46,7 @@ def handle_missing(df, strategy='drop', columns=None):
         raise TypeError('columns must be a list.')
 
     if columns is None:
-        columns = [None]
+        columns = df.columns.tolist()
 
     for col in columns:
         if col not in df.columns:
@@ -59,7 +59,7 @@ def handle_missing(df, strategy='drop', columns=None):
             raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
 
         if strategy == 'drop':
-            df[col] = df[col].dropna()
+            df = df.dropna(subset=[col], inplace=True)
 
         if df[col].dtype in ['int', 'float']:
             if strategy == 'mean':

--- a/src/dsci_524_group23/handle_missing.py
+++ b/src/dsci_524_group23/handle_missing.py
@@ -42,28 +42,30 @@ def handle_missing(df, strategy='drop', columns=None):
     if not isinstance(df, pd.DataFrame):
         raise TypeError('df must be a pandas DataFrame.')
 
-    if not isinstance(columns, list) and columns is not None:
-        raise TypeError('columns must be a list.')
-
     if columns is None:
         columns = df.columns.tolist()
+
+    if not isinstance(columns, list):
+        raise TypeError('columns must be a list.')
+
+    df = df.copy()
 
     for col in columns:
         if col not in df.columns:
             raise ValueError(f'Column {col} not in dataframe.')
 
-        if df[col].isna().sum() == df[col].shape[0]:
+        if df[col].isna().all():
             raise ValueError(f'Column {col} only contains NaN.')
-
-        if df[col].dtype not in ['object', 'category', 'bool', 'int', 'float', 'str']:
-            raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
-
-        if df[col].isna().sum() == 0:
-            continue
 
         if strategy == 'drop':
             df = df.dropna(subset=[col], inplace=True)
             continue
+
+        if df[col].isna().sum() == 0:
+            continue
+
+        if df[col].dtype not in ['object', 'category', 'bool', 'int', 'float', 'str']:
+            raise TypeError(f'The dtype of column {col} cannot be used. \nColumn {col} has dtype {df[col].dtype}.')
 
         if df[col].dtype in ['int', 'float']:
             if strategy == 'mean':
@@ -84,3 +86,5 @@ def handle_missing(df, strategy='drop', columns=None):
         if df[col].dtype in ['object', 'category', 'bool']:
             if strategy == 'mode':
                 df[col] = df[col].fillna(df[col].mode())
+
+    return df

--- a/tests/unit/test_handle_missing.py
+++ b/tests/unit/test_handle_missing.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from pandas.testing import assert_frame_equal
 from dsci_524_group23.handle_missing import handle_missing
+import pytest
 
 
 def test_handle_missing():

--- a/tests/unit/test_handle_missing.py
+++ b/tests/unit/test_handle_missing.py
@@ -39,7 +39,7 @@ def test_handle_missing():
     except AssertionError:
         print("Test 'mode' failed.")
 
-    # --- Test 3: Strategy 'drop' (Known Failure in current code) ---
+    # --- Test 3: Strategy 'drop' ---
     # Expected: Row 2 should be removed entirely
     df_drop = df.copy()
     res_drop = handle_missing(df_drop, strategy='drop')
@@ -65,7 +65,13 @@ def test_handle_missing():
     except TypeError:
         print("Test 'invalid dtype error' passed.")
 
-
-# To run the test explicitly
-if __name__ == "__main__":
-    test_handle_missing()
+    # Test invalid input type in arg
+    df_type = df.copy()
+    try:
+        handle_missing(df_type, strategy='mean', columns=5)
+    except TypeError:
+        print("Test 'invalid input type error' passed.")
+    try:
+        handle_missing(df_type, strategy=4)
+    except TypeError:
+        print("Test 'invalid input type error' passed.")

--- a/tests/unit/test_handle_missing.py
+++ b/tests/unit/test_handle_missing.py
@@ -1,0 +1,5 @@
+import pandas as pd
+from dsci_524_group23.handle_missing import handle_missing
+
+def test_handle_missing():
+    pass

--- a/tests/unit/test_handle_missing.py
+++ b/tests/unit/test_handle_missing.py
@@ -1,5 +1,71 @@
 import pandas as pd
+import numpy as np
+from pandas.testing import assert_frame_equal
 from dsci_524_group23.handle_missing import handle_missing
 
+
 def test_handle_missing():
-    pass
+    # Setup Data
+    data = {
+        'A': [1, 2, np.nan, 4, 4],
+        'B': ['x', 'y', np.nan, 'x', 'x'],
+        'C': [10, 20, 30, 40, 50]
+    }
+    df = pd.DataFrame(data)
+
+    # --- Test 1: Strategy 'mean' ---
+    df_mean = df.copy()
+    res_mean = handle_missing(df_mean, strategy='mean', columns=['A'])
+
+    expected_mean = df.copy()
+    expected_mean.loc[2, 'A'] = 2.75
+
+    try:
+        assert_frame_equal(res_mean[['A']], expected_mean[['A']])
+        print("Test 'mean' passed.")
+    except AssertionError:
+        print("Test 'mean' failed.")
+
+    # --- Test 2: Strategy 'mode' on Object column ---
+    df_mode = df.copy()
+    res_mode = handle_missing(df_mode, strategy='mode', columns=['B'])
+
+    expected_mode = df.copy()
+    expected_mode.loc[2, 'B'] = 'x'
+
+    try:
+        assert_frame_equal(res_mode[['B']], expected_mode[['B']])
+        print("Test 'mode' passed.")
+    except AssertionError:
+        print("Test 'mode' failed.")
+
+    # --- Test 3: Strategy 'drop' (Known Failure in current code) ---
+    # Expected: Row 2 should be removed entirely
+    df_drop = df.copy()
+    res_drop = handle_missing(df_drop, strategy='drop')
+    try:
+        assert len(res_drop) == 4
+        assert 2 not in res_drop.index
+        print("Test 'drop' passed.")
+    except AssertionError:
+        print("Test 'drop' failed.")
+
+    # --- Test 4: Error Handling ---
+    # Test Invalid Strategy
+    try:
+        handle_missing(df, strategy='magic', columns=['A'])
+    except ValueError:
+        print("Test 'invalid strategy error' passed.")
+
+    # Test Invalid dtype
+    df_datetime = df.copy()
+    df_datetime['D'] = [pd.to_datetime('05-05-2025'), pd.to_datetime('05-05-2026'), np.nan, np.nan, np.nan]
+    try:
+        handle_missing(df_datetime, strategy='mode', columns=['D'])
+    except TypeError:
+        print("Test 'invalid dtype error' passed.")
+
+
+# To run the test explicitly
+if __name__ == "__main__":
+    test_handle_missing()


### PR DESCRIPTION
Closes #18 
Closes #19 
Closes #20
Closes #21

LLM prompts basically consist of asking how to check data types robustly in pandas and the edges that were not initially considered. None of the code was generated by LLMs.